### PR TITLE
fix: forward Home Assistant setup port

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ docker exec -it haos systemctl restart docker
 | --- | --- | --- |
 | `USE_DUMMY_NETWORKMANAGER` | Disable NetworkManager and enable the dummy responder inside `haos-one-compat` | `1` |
 | `USE_UDEV_SHIM` | Inject an idle Supervisor udev monitor when needed (`auto`, `force`, or `off`) | `auto` |
+| `SETUP_PORT` | Forward the Home Assistant HTTP setup port to Core. | unset — `80` from Home Assistant 2026.8; `8123` prior ([docs](https://www.home-assistant.io/integrations/http/#server-port)) |
 | `DEV` | Used for development purposes - mount live `haos-one-compat` code volume | `0` |
 
 When the udev shim is enabled, upgrading an existing installation automatically

--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -58,7 +58,7 @@ mkdir -p /etc/systemd/system/haos-one-compat.service.d
 cat > /etc/systemd/system/haos-one-compat.service.d/override.conf <<EOF
 [Service]
 ExecStart=
-ExecStart=/usr/bin/docker run --name haos_one_compat -e USE_DUMMY_NETWORKMANAGER=$use_dummy_networkmanager -e USE_UDEV_SHIM=$use_udev_shim -v /run/dbus:/run/dbus -v /run:/host-run haos_one_compat
+ExecStart=/usr/bin/docker run --name haos_one_compat -e USE_DUMMY_NETWORKMANAGER=$use_dummy_networkmanager -e USE_UDEV_SHIM=$use_udev_shim -e SETUP_PORT=${SETUP_PORT:-} -v /run/dbus:/run/dbus -v /run:/host-run haos_one_compat
 EOF
 
 # Disable in-container udev; Supervisor uses host udev data and the compatibility
@@ -90,7 +90,7 @@ case "${DEV:-0}" in
     cat > /etc/systemd/system/haos-one-compat.service.d/override.conf <<EOF
 [Service]
 ExecStart=
-ExecStart=/usr/bin/docker run --name haos_one_compat -e USE_DUMMY_NETWORKMANAGER=$use_dummy_networkmanager -e USE_UDEV_SHIM=$use_udev_shim -v /run/dbus:/run/dbus -v /run:/host-run -v /opt/haos-one-compat:/opt/haos-one-compat haos_one_compat
+ExecStart=/usr/bin/docker run --name haos_one_compat -e USE_DUMMY_NETWORKMANAGER=$use_dummy_networkmanager -e USE_UDEV_SHIM=$use_udev_shim -e SETUP_PORT=${SETUP_PORT:-} -v /run/dbus:/run/dbus -v /run:/host-run -v /opt/haos-one-compat:/opt/haos-one-compat haos_one_compat
 EOF
     ;;
 esac

--- a/rootfs/opt/haos-one-compat/haos_one_compat/__main__.py
+++ b/rootfs/opt/haos-one-compat/haos_one_compat/__main__.py
@@ -52,10 +52,15 @@ async def run_services(args) -> None:
         mode or "auto",
         inject_udev_shim,
     )
+    setup_port = os.getenv("SETUP_PORT") or None
+    if setup_port:
+        _LOGGER.info("Home Assistant SETUP_PORT override=%s", setup_port)
+
     proxy = DockerSocketProxy(
         frontend_path=args.frontend_socket,
         upstream_path=args.upstream_socket,
         inject_udev_shim=inject_udev_shim,
+        setup_port=setup_port,
     )
     tasks = {
         asyncio.create_task(proxy.serve_forever(), name="docker-proxy"),

--- a/rootfs/opt/haos-one-compat/haos_one_compat/docker_proxy.py
+++ b/rootfs/opt/haos-one-compat/haos_one_compat/docker_proxy.py
@@ -209,12 +209,14 @@ def rewrite_http_request(
     body: bytes,
     *,
     inject_udev_shim: bool = False,
+    setup_port: str | None = None,
 ) -> bytes:
     """Serialize a container-create request with compatibility options removed."""
     rewritten_body = rewrite_create_request_payload(
         request.path,
         body,
         inject_udev_shim=inject_udev_shim,
+        setup_port=setup_port,
     )
     if rewritten_body == body:
         return request.raw + body
@@ -337,10 +339,12 @@ class DockerSocketProxy:
         upstream_path: str,
         *,
         inject_udev_shim: bool = False,
+        setup_port: str | None = None,
     ) -> None:
         self.frontend_path = frontend_path
         self.upstream_path = upstream_path
         self.inject_udev_shim = inject_udev_shim
+        self.setup_port = setup_port
         self._server: asyncio.AbstractServer | None = None
 
     async def _wait_for_upstream(self, timeout: float = 30.0) -> None:
@@ -419,6 +423,7 @@ class DockerSocketProxy:
                         request,
                         body,
                         inject_udev_shim=self.inject_udev_shim,
+                        setup_port=self.setup_port,
                     )
                     if rewritten_request == request.raw + body:
                         upstream_writer.write(request.raw + raw_body)

--- a/rootfs/opt/haos-one-compat/haos_one_compat/docker_rules.py
+++ b/rootfs/opt/haos-one-compat/haos_one_compat/docker_rules.py
@@ -38,6 +38,7 @@ def rewrite_create_request_payload(
     payload: bytes,
     *,
     inject_udev_shim: bool = False,
+    setup_port: str | None = None,
 ) -> bytes:
     """Remove container-create options unsupported by nested unprivileged LXC."""
     if not is_create_request(path):
@@ -61,6 +62,9 @@ def rewrite_create_request_payload(
 
     if inject_udev_shim and _is_supervisor_create(path, data):
         changed = _inject_udev_shim(data) or changed
+
+    if setup_port and _is_homeassistant_create(path, data):
+        changed = _inject_env(data, "SETUP_PORT", setup_port) or changed
 
     if not changed:
         return payload
@@ -99,6 +103,39 @@ def _is_supervisor_create(path: str, data: dict[str, Any]) -> bool:
 
     image = data.get("Image")
     return isinstance(image, str) and "hassio-supervisor" in image.lower()
+
+
+def _is_homeassistant_create(path: str, data: dict[str, Any]) -> bool:
+    target = urlsplit(path)
+    names = parse_qs(target.query).get("name", [])
+    return any(name.lstrip("/") == "homeassistant" for name in names)
+
+
+def _inject_env(data: dict[str, Any], name: str, value: str) -> bool:
+    environment = data.get("Env")
+    if environment is None:
+        environment = []
+        data["Env"] = environment
+    if not isinstance(environment, list):
+        return False
+
+    prefix = f"{name}="
+    index = next(
+        (
+            index
+            for index, item in enumerate(environment)
+            if isinstance(item, str) and item.startswith(prefix)
+        ),
+        None,
+    )
+    wanted = f"{name}={value}"
+    if index is None:
+        environment.append(wanted)
+        return True
+    if environment[index] != wanted:
+        environment[index] = wanted
+        return True
+    return False
 
 
 def _inject_udev_shim(data: dict[str, Any]) -> bool:

--- a/rootfs/opt/haos-one-compat/tests/test_docker_proxy.py
+++ b/rootfs/opt/haos-one-compat/tests/test_docker_proxy.py
@@ -230,6 +230,24 @@ class DockerProxyTests(unittest.IsolatedAsyncioTestCase):
             len(self.request_bodies[-1]),
         )
 
+    async def test_injects_setup_port_into_homeassistant_create(self) -> None:
+        self.proxy.setup_port = "8123"
+        payload = json.dumps(
+            {
+                "Image": "ghcr.io/home-assistant/qemux86-64-homeassistant:2026.8.2",
+                "Env": ["SUPERVISOR=http://supervisor"],
+                "HostConfig": {"NetworkMode": "host"},
+            }
+        ).encode()
+
+        await self._post_json(
+            "/v1.47/containers/create?name=homeassistant",
+            payload,
+        )
+
+        rewritten = json.loads(self.request_bodies[-1])
+        self.assertIn("SETUP_PORT=8123", rewritten["Env"])
+
     async def test_injects_udev_shim_into_supervisor_create(self) -> None:
         self.proxy.inject_udev_shim = True
         payload = json.dumps(

--- a/rootfs/opt/haos-one-compat/tests/test_docker_rules.py
+++ b/rootfs/opt/haos-one-compat/tests/test_docker_rules.py
@@ -103,6 +103,47 @@ class DockerRulesTests(unittest.TestCase):
             payload,
         )
 
+    def test_homeassistant_create_injects_setup_port(self) -> None:
+        payload = json.dumps(
+            {
+                "Image": "ghcr.io/home-assistant/qemux86-64-homeassistant:2026.8.2",
+                "Env": ["SUPERVISOR=http://supervisor"],
+                "HostConfig": {"NetworkMode": "host"},
+            }
+        ).encode()
+
+        rewritten = json.loads(
+            rewrite_create_request_payload(
+                "/v1.47/containers/create?name=homeassistant",
+                payload,
+                setup_port="8123",
+            )
+        )
+
+        self.assertIn("SETUP_PORT=8123", rewritten["Env"])
+
+    def test_homeassistant_create_replaces_existing_setup_port(self) -> None:
+        payload = b'{"Env":["SETUP_PORT=80","OTHER=value"],"HostConfig":{}}'
+        rewritten = json.loads(
+            rewrite_create_request_payload(
+                "/containers/create?name=homeassistant",
+                payload,
+                setup_port="8123",
+            )
+        )
+        self.assertEqual(rewritten["Env"], ["SETUP_PORT=8123", "OTHER=value"])
+
+    def test_setup_port_is_not_injected_into_other_containers(self) -> None:
+        payload = b'{"Image":"alpine:latest","HostConfig":{}}'
+        self.assertIs(
+            rewrite_create_request_payload(
+                "/containers/create?name=addon_test",
+                payload,
+                setup_port="8123",
+            ),
+            payload,
+        )
+
     def test_supervisor_create_injects_udev_shim(self) -> None:
         payload = json.dumps(
             {


### PR DESCRIPTION
Forward `SETUP_PORT` from the outer haos-one container into the Supervisor-created Home Assistant Core container. This allows preserving port 8123 on Home Assistant 2026.8+ when port 80 is occupied.