### PR TITLE
fix: route setup landing page to custom port

### DIFF
--- a/rootfs/opt/haos-one-compat/haos_one_compat/docker_rules.py
+++ b/rootfs/opt/haos-one-compat/haos_one_compat/docker_rules.py
@@ -65,6 +65,8 @@ def rewrite_create_request_payload(
 
     if setup_port and _is_homeassistant_create(path, data):
         changed = _inject_env(data, "SETUP_PORT", setup_port) or changed
+        if _is_homeassistant_landingpage_create(data):
+            changed = _publish_landingpage_port(data, setup_port) or changed
 
     if not changed:
         return payload
@@ -109,6 +111,42 @@ def _is_homeassistant_create(path: str, data: dict[str, Any]) -> bool:
     target = urlsplit(path)
     names = parse_qs(target.query).get("name", [])
     return any(name.lstrip("/") == "homeassistant" for name in names)
+
+
+def _is_homeassistant_landingpage_create(data: dict[str, Any]) -> bool:
+    image = data.get("Image")
+    return isinstance(image, str) and image.endswith(":landingpage")
+
+
+def _publish_landingpage_port(data: dict[str, Any], setup_port: str) -> bool:
+    try:
+        port = int(setup_port)
+    except ValueError:
+        return False
+    if port < 1 or port > 65535:
+        return False
+
+    host_config = data.get("HostConfig")
+    if not isinstance(host_config, dict):
+        return False
+
+    changed = host_config.get("NetworkMode") != "hassio"
+    host_config["NetworkMode"] = "hassio"
+
+    wanted_binding = [{"HostIp": "", "HostPort": str(port)}]
+    port_bindings = host_config.setdefault("PortBindings", {})
+    if not isinstance(port_bindings, dict):
+        return changed
+    if port_bindings.get("80/tcp") != wanted_binding:
+        port_bindings["80/tcp"] = wanted_binding
+        changed = True
+
+    exposed_ports = data.setdefault("ExposedPorts", {})
+    if isinstance(exposed_ports, dict) and "80/tcp" not in exposed_ports:
+        exposed_ports["80/tcp"] = {}
+        changed = True
+
+    return changed
 
 
 def _inject_env(data: dict[str, Any], name: str, value: str) -> bool:

--- a/rootfs/opt/haos-one-compat/tests/test_docker_rules.py
+++ b/rootfs/opt/haos-one-compat/tests/test_docker_rules.py
@@ -122,6 +122,51 @@ class DockerRulesTests(unittest.TestCase):
 
         self.assertIn("SETUP_PORT=8123", rewritten["Env"])
 
+    def test_landingpage_uses_hassio_network_and_publishes_setup_port(self) -> None:
+        payload = json.dumps(
+            {
+                "Image": "ghcr.io/home-assistant/qemux86-64-homeassistant:landingpage",
+                "Env": ["SUPERVISOR=172.30.32.2"],
+                "HostConfig": {"NetworkMode": "host", "PortBindings": {}},
+            }
+        ).encode()
+
+        rewritten = json.loads(
+            rewrite_create_request_payload(
+                "/containers/create?name=homeassistant",
+                payload,
+                setup_port="8765",
+            )
+        )
+
+        self.assertEqual(rewritten["HostConfig"]["NetworkMode"], "hassio")
+        self.assertEqual(
+            rewritten["HostConfig"]["PortBindings"]["80/tcp"],
+            [{"HostIp": "", "HostPort": "8765"}],
+        )
+        self.assertEqual(rewritten["ExposedPorts"]["80/tcp"], {})
+        self.assertIn("SETUP_PORT=8765", rewritten["Env"])
+
+    def test_core_keeps_host_network_with_setup_port(self) -> None:
+        payload = json.dumps(
+            {
+                "Image": "ghcr.io/home-assistant/qemux86-64-homeassistant:2026.8.2",
+                "HostConfig": {"NetworkMode": "host", "PortBindings": {}},
+            }
+        ).encode()
+
+        rewritten = json.loads(
+            rewrite_create_request_payload(
+                "/containers/create?name=homeassistant",
+                payload,
+                setup_port="8765",
+            )
+        )
+
+        self.assertEqual(rewritten["HostConfig"]["NetworkMode"], "host")
+        self.assertEqual(rewritten["HostConfig"]["PortBindings"], {})
+        self.assertIn("SETUP_PORT=8765", rewritten["Env"])
+
     def test_homeassistant_create_replaces_existing_setup_port(self) -> None:
         payload = b'{"Env":["SETUP_PORT=80","OTHER=value"],"HostConfig":{}}'
         rewritten = json.loads(


### PR DESCRIPTION
Route the temporary Home Assistant landing-page container through the `hassio` network and publish its internal port 80 on `SETUP_PORT`, while leaving the real Core container on host networking with the existing `SETUP_PORT` injection.

Verified locally with port 80 occupied and `SETUP_PORT=8768`: the landing page returned HTTP 200 on 8768, then Core replaced it and returned HTTP 302 on the same port.